### PR TITLE
travis: PHP 5.6 and 7.0 nightly added + other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,22 @@
 language: php
+
 php:
   - 5.3.3
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
 
-script:
- - vendor/bin/phpunit
+matrix:
+  allow_failures:
+    - php: 7.0
 
 before_script:
- - sudo apt-get -qq update > /dev/null
- - phpenv rehash > /dev/null
- - composer selfupdate --quiet
- - composer install --dev --prefer-source
- - vendor/bin/phpunit
- - composer update --dev --prefer-source
+ - composer install --prefer-source
+
+script:
+ - phpunit
 
 notifications:
   irc: "irc.freenode.org#phpdocumentor"


### PR DESCRIPTION
- composer self-update has no really added value (updated by default with every PHP patch version)
- `--dev` is by default for couple of months
- use Travis' phpunit (same as for updating composer, Travis can handle it better and we don't need to check it)
- mess cleanup

---

I can send PR to other repos if accepted. Just wanted to start with something simple.