### PR TITLE
dependency update to allow symfony 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "autoload": { "psr-0":{ "phpDocumentor": ["src/", "tests/unit/"] } },
     "require": {
         "php": ">=5.3.3",
-        "symfony/finder": "~2.1"
+        "symfony/finder": "~2.1|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"


### PR DESCRIPTION
currently phpdoc can't be used on a symfony 3.x project because phpdoc/fileset requires a symfony 2.x version of finder.  Updating the composer requirements to allow 3.x for symfony/finder